### PR TITLE
Support fetching a missing intermediate certificate like a browser would

### DIFF
--- a/cmd/retrieve/main.go
+++ b/cmd/retrieve/main.go
@@ -15,7 +15,7 @@ func main() {
 	acct := os.Getenv("WATER_ACCT")
 
 	if len(os.Args) != 3 {
-		log.Fatalf("usage: <hourly|monthly> <yyyyMM>")
+		log.Fatalf("usage: <hourly|daily> <yyyyMM>")
 	}
 
 	start, err := time.Parse("200601", os.Args[2])

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mctofu/water-monitor
 require (
 	github.com/aws/aws-lambda-go v1.41.0
 	github.com/aws/aws-sdk-go v1.44.312
+	github.com/fcjr/aia-transport-go v1.2.2
 	github.com/headzoo/surf v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+9
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/fcjr/aia-transport-go v1.2.2 h1:sIZqXcM+YhTd2BDtkV2OJaqbcIVcPv1oKru3VJPIPc8=
+github.com/fcjr/aia-transport-go v1.2.2/go.mod h1:onSqSq3tGkM14WusDx7q9FTheS9R1KBtD+QBWI6zG/w=
 github.com/headzoo/surf v1.0.1 h1:wk3+LT8gjnCxEwfBJl6MhaNg154En5KjgmgzAG9uMS0=
 github.com/headzoo/surf v1.0.1/go.mod h1:/bct0m/iMNEqpn520y01yoaWxsAEigGFPnvyR1ewR5M=
 github.com/headzoo/ut v0.0.0-20181013193318-a13b5a7a02ca h1:utFgFwgxaqx5OthzE3DSGrtOq7rox5r2sxZ2wbfTuK0=

--- a/water/water.go
+++ b/water/water.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fcjr/aia-transport-go"
 	"github.com/headzoo/surf"
 	"github.com/headzoo/surf/browser"
 )
@@ -47,7 +48,15 @@ func login(user, pass, acct string) (*browser.Browser, error) {
 	b := surf.NewBrowser()
 	b.SetUserAgent("Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36")
 	b.AddRequestHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-	err := b.Open("https://myaccount.sfwater.org/")
+
+	// workaround incomplete certificate chain
+	tr, err := aia.NewTransport()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create incomplete certificate chain workaround transport: %v", err)
+	}
+	b.SetTransport(tr)
+
+	err = b.Open("https://myaccount.sfwater.org/")
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open site: %v", err)
 	}


### PR DESCRIPTION
The sf water site certificate chain is incomplete which causes validation
to fail without this addition to dynamically fetch the missing cert.